### PR TITLE
Changes phpstan level to be consistent with configured level in phpstan.neon

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -121,7 +121,7 @@
             "@rector-fix",
             "@lint-php"
         ],
-        "phpstan": "vendor/bin/phpstan analyse docroot/modules/custom docroot/themes/custom --level max || true",
+        "phpstan": "vendor/bin/phpstan analyse docroot/modules/custom docroot/themes/custom || true",
         "rector-modules": "vendor/bin/rector process docroot/modules/custom/ --dry-run || true",
         "rector-themes": "vendor/bin/rector process docroot/themes/custom/ --dry-run || true",
         "rector-fix-modules": "vendor/bin/rector process docroot/modules/custom/ || true",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,7 @@
 parameters:
-  level: max
+  # Prevents classes extending Drupal core from having to take unnecessary
+  # steps to workaround current phpdoc standards in Drupal core.
+  level: 5
   customRulesetUsed: true
   reportUnmatchedIgnoredErrors: false
   excludePaths:


### PR DESCRIPTION
## Description
> As a developer, I want phpstan configuration to not be overridden, so that I can develop without having to workaround phpdoc blocks defined by Drupal core.

1. Removes level override from composer.json phpstan script
2. Reduces phpstan level to 5 for optimal Drupal coding experience.

## Affected URL

N/A

## Related Tickets

N/A

## Steps to Validate

`composer run-script phpstan` uses the level defined in phpstan.neon

## Deploy Notes

N/A