### PR TITLE
Codexmas hooks config sync issue

### DIFF
--- a/hooks/common/post-code-deploy/post-deployment.sh
+++ b/hooks/common/post-code-deploy/post-deployment.sh
@@ -17,7 +17,7 @@ echo "Clear cache"
 drush10 @$drush_alias cr
 
 echo "Import config"
-drush10 @$drush_alias cim --source=../config/sync -y
+drush10 @$drush_alias cim -y
 
 echo "Update modules"
 drush10 @$drush_alias updb -y

--- a/hooks/common/post-code-update/post-deployment.sh
+++ b/hooks/common/post-code-update/post-deployment.sh
@@ -17,7 +17,7 @@ echo "Clear cache"
 drush10 @$drush_alias cr
 
 echo "Import config"
-drush10 @$drush_alias cim --source=../config/sync -y
+drush10 @$drush_alias cim -y
 
 echo "Update modules"
 drush10 @$drush_alias updb -y


### PR DESCRIPTION
## Description
> As a developer, having the hook correctly run `drush cim -y` is necessary.

_Configuring your config sync directory is a best practice and it may vary from project to project. So lets not have a hardcoded sync path in the hooks_

## Steps to Validate
1. Make a commit to a branch which is checked out on an Acquia environment
1. Review the log for the environment and watch for the config import output to appear
1. Celebrate
